### PR TITLE
Job queue does not uniquely assign jobs

### DIFF
--- a/backend/integration-tests/src/main.rs
+++ b/backend/integration-tests/src/main.rs
@@ -210,7 +210,7 @@ async fn test_wrong_password() -> anyhow::Result<()> {
             "/accounts/login",
             Login {
                 name: "lothar".to_owned(),
-                password: "anders".to_owned().into(),
+                password: "anders++".to_owned().into(),
             },
         )
         .await?;

--- a/backend/integration-tests/src/util.rs
+++ b/backend/integration-tests/src/util.rs
@@ -57,10 +57,10 @@ impl HttpClient {
 pub async fn assert_response_status(response: Response, status: StatusCode) -> anyhow::Result<()> {
     if response.status() != status {
         bail!(
-            "unexpected response: {}\nexpected: {}\n{:?}\n",
+            "unexpected response: {}\nexpected: {}\ncontent:\n{:?}\n",
             response.status(),
             status,
-            std::str::from_utf8(response.bytes().await.unwrap().as_ref()),
+            String::from_utf8_lossy(response.bytes().await.unwrap().as_ref()),
         );
     } else {
         Ok(())

--- a/backend/rvoc-backend/src/configuration/mod.rs
+++ b/backend/rvoc-backend/src/configuration/mod.rs
@@ -149,6 +149,14 @@ impl Configuration {
             )?),
         };
 
+        if result.shutdown_timeout < Duration::zero() {
+            return Err(RVocError::NegativeShutdownTimeout);
+        }
+
+        if result.job_queue_poll_interval < Duration::zero() {
+            return Err(RVocError::NegativeJobQueuePollInterval);
+        }
+
         let password_pepper_length = result.password_pepper.unsecure().len();
         let password_pepper_min_length = 8;
         let password_pepper_max_length = 64;

--- a/backend/rvoc-backend/src/database/model.rs
+++ b/backend/rvoc-backend/src/database/model.rs
@@ -10,3 +10,12 @@ pub struct ScheduledJob {
     pub name: String,
     pub in_progress: bool,
 }
+
+impl ScheduledJob {
+    /// Sets `in_progress` to `true`, but panics if it was set to true already.
+    pub fn set_in_progress(mut self) -> Self {
+        assert!(!self.in_progress);
+        self.in_progress = true;
+        self
+    }
+}

--- a/backend/rvoc-backend/src/error/mod.rs
+++ b/backend/rvoc-backend/src/error/mod.rs
@@ -18,6 +18,12 @@ pub enum RVocError {
         source: BoxDynError,
     },
 
+    #[error("the configured shutdown timeout is negative")]
+    NegativeShutdownTimeout,
+
+    #[error("the configured job queue poll interval is negative")]
+    NegativeJobQueuePollInterval,
+
     #[error("setting up tracing failed: {source}")]
     SetupTracing { source: BoxDynError },
 

--- a/backend/rvoc-backend/src/job_queue/mod.rs
+++ b/backend/rvoc-backend/src/job_queue/mod.rs
@@ -237,6 +237,7 @@ async fn complete_job(
             |database_connection| {
                 Box::pin(async move {
                     use crate::database::schema::job_queue::dsl::*;
+                    use diesel::ExpressionMethods;
                     use diesel_async::RunQueryDsl;
 
                     // Schedule the next execution.
@@ -251,6 +252,7 @@ async fn complete_job(
                     }
 
                     diesel::update(job_queue)
+                        .filter(name.eq(next_scheduled_execution.name.clone()))
                         .set(next_scheduled_execution)
                         .execute(database_connection)
                         .await?;

--- a/backend/rvoc-backend/src/job_queue/mod.rs
+++ b/backend/rvoc-backend/src/job_queue/mod.rs
@@ -29,7 +29,13 @@ pub async fn spawn_job_queue_runner(
     Ok(tokio::spawn(async move {
         use tokio::time;
 
-        let mut interval = time::interval(time::Duration::from_secs(1));
+        let mut interval = time::interval(time::Duration::from_secs(
+            configuration
+                .job_queue_poll_interval
+                .num_seconds()
+                .try_into()
+                .unwrap(),
+        ));
         interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
 
         while !shutdown_flag.load(atomic::Ordering::Relaxed) {

--- a/backend/rvoc-backend/src/web/authentication.rs
+++ b/backend/rvoc-backend/src/web/authentication.rs
@@ -93,8 +93,8 @@ pub async fn login(
 
                         if affected_rows != 1 {
                             unreachable!(
-                            "Updated exactly one existing row, but {affected_rows} were affected"
-                        );
+                                "Updated exactly one existing row, but {affected_rows} were affected"
+                            );
                         }
                     }
 

--- a/backend/rvoc-backend/src/web/mod.rs
+++ b/backend/rvoc-backend/src/web/mod.rs
@@ -83,6 +83,7 @@ pub async fn run_web_api(
 impl IntoResponse for RVocError {
     fn into_response(self) -> axum::response::Response {
         if let RVocError::UserError(user_error) = self {
+            error!("User error: {user_error:?}");
             user_error.into_response()
         } else {
             error!("Web API error: {self:?}");


### PR DESCRIPTION
This contains just some other fixes now. It seems like the job queue did actually uniquely assign jobs.

We first query for a job that is not running, and then set it to running. This would mean that if two simultaneous transactions would set the same job to running, then one of them would encounter a serialisation failure.