### PR TITLE
Add integration test mode

### DIFF
--- a/.github/workflows/web-api-ci.yml
+++ b/.github/workflows/web-api-ci.yml
@@ -61,7 +61,9 @@ jobs:
       run: nix build --out-link integrationTestsBinary .#integrationTestsBinary
 
     - name: Set up environment variables
-      run: echo "PASSWORD_PEPPER=test-test-test-test" >> $GITHUB_ENV
+      run: | 
+        echo "PASSWORD_PEPPER=test-test-test-test" >> $GITHUB_ENV
+        echo "RVOC_INTEGRATION_TEST_MODE=true" >> $GITHUB_ENV
 
     - name: Run database migrations
       run: debugBinary/bin/rvoc-backend apply-migrations

--- a/backend/rvoc-backend/src/configuration/mod.rs
+++ b/backend/rvoc-backend/src/configuration/mod.rs
@@ -10,6 +10,11 @@ use secstr::SecUtf8;
 /// The configuration of the application.
 #[derive(Debug, Clone)]
 pub struct Configuration {
+    /// If set, then some features that are unsuitable for integration tests are disabled.
+    /// For example:
+    ///  * Do not run the wiktionary update.
+    pub integration_test_mode: bool,
+
     /// The url to access postgres.
     pub postgres_url: SecUtf8,
 
@@ -81,6 +86,10 @@ impl Configuration {
     /// Read the configuration values from environment variables.
     pub fn from_environment() -> RVocResult<Self> {
         let result = Self {
+            integration_test_mode: read_env_var_with_default_as_type(
+                "RVOC_INTEGRATION_TEST_MODE",
+                false,
+            )?,
             postgres_url: read_env_var_with_default_as_type(
                 "POSTGRES_RVOC_URL",
                 "postgres://rvoc@localhost/rvoc",
@@ -186,6 +195,7 @@ impl Configuration {
 
     pub fn test_configuration() -> Self {
         Self {
+            integration_test_mode: true,
             postgres_url: "postgres://rvoc@localhost/rvoc".into(),
             opentelemetry_url: None,
             shutdown_timeout: Duration::seconds(30),

--- a/backend/rvoc-backend/src/job_queue/jobs/update_witkionary.rs
+++ b/backend/rvoc-backend/src/job_queue/jobs/update_witkionary.rs
@@ -1,3 +1,5 @@
+use tracing::warn;
+
 use crate::{
     configuration::Configuration, database::RVocAsyncDatabaseConnectionPool, error::RVocResult,
     update_wiktionary::run_update_wiktionary,
@@ -7,5 +9,10 @@ pub async fn update_wiktionary(
     database_connection_pool: &RVocAsyncDatabaseConnectionPool,
     configuration: &Configuration,
 ) -> RVocResult<()> {
+    if configuration.integration_test_mode {
+        warn!("Not running update_wiktionary because integration_test_mode is enabled");
+        return Ok(());
+    }
+
     run_update_wiktionary(database_connection_pool, configuration).await
 }


### PR DESCRIPTION
Web API CI is now run in this mode.
For now, it only disables the wiktionary update.